### PR TITLE
Fix #36 and dragging events

### DIFF
--- a/map-view-common.ts
+++ b/map-view-common.ts
@@ -24,6 +24,10 @@ export abstract class MapView extends View implements IMapView {
 
     public static mapReadyEvent: string = "mapReady";
     public static markerSelectEvent: string = "markerSelect";
+    
+    public static markerBeginDraggingEvent: string = "markerBeginDragging";
+    public static markerEndDraggingEvent: string = "markerEndDragging";
+    
     public static coordinateTappedEvent: string = "coordinateTapped";
     public static cameraChangedEvent: string = "cameraChanged";
 

--- a/map-view.android.ts
+++ b/map-view.android.ts
@@ -124,6 +124,13 @@ export class MapView extends MapViewCommon {
     notifyMarkerTapped(marker: Marker) {
         this.notifyMarkerEvent(MapViewCommon.markerSelectEvent, marker);
     }
+    
+    notifyMarkerEndDragging(marker: Marker) {
+        this.notifyMarkerEvent(MapViewCommon.markerEndDraggingEvent, marker);
+    }
+    notifyMarkerBeginDragging(marker: Marker) {
+        this.notifyMarkerEvent(MapViewCommon.markerBeginDraggingEvent, marker);
+    }
 
     addPolyline(shape: Polyline) {
         shape.loadPoints();
@@ -283,7 +290,7 @@ export class Position extends PositionBase {
     }
 
     get longitude() {
-        return this._android.latitude;
+        return this._android.longitude;
     }
 
     set longitude(longitude) {

--- a/map-view.ios.ts
+++ b/map-view.ios.ts
@@ -145,6 +145,15 @@ export class MapView extends MapViewCommon {
         this.notifyMarkerEvent(MapViewCommon.markerSelectEvent, marker);
     }
 
+
+    notifyMarkerEndDragging(marker: Marker) {
+        this.notifyMarkerEvent(MapViewCommon.markerEndDraggingEvent, marker);
+    }
+    notifyMarkerBeginDragging(marker: Marker) {
+        this.notifyMarkerEvent(MapViewCommon.markerBeginDraggingEvent, marker);
+    }
+
+
     addPolyline(shape: Polyline) {
         shape.loadPoints();
         shape.ios.map = this.gMap;
@@ -199,7 +208,7 @@ export class Position extends PositionBase {
     }
 
     get longitude() {
-        return this._ios.latitude;
+        return this._ios.longitude;
     }
 
     set longitude(longitude) {


### PR DESCRIPTION
Fix for #36 // Typo - get longitude method.

Cocoa offers: marker start dragging event and marker end dragging event, I just added a couple of lines to use it.
